### PR TITLE
Fix CodeBuild CDK deploy invocation in buildspec

### DIFF
--- a/infra/buildspec.yml
+++ b/infra/buildspec.yml
@@ -16,7 +16,7 @@ phases:
       - pnpm run build:all
       - echo "🚀 Desplegando infraestructura con CDK..."
       - pnpm run cdk:synth
-      - npx cdk deploy CoreStack --require-approval never
+      - pnpm run cdk:deploy -- CoreStack --require-approval never
 cache:
   paths:
     - '/root/.pnpm-store'


### PR DESCRIPTION
## Summary
- update the CodeBuild buildspec to execute `cdk deploy` through the pnpm workspace script so the command runs from the CDK package directory

## Testing
- pnpm run cdk:synth

------
https://chatgpt.com/codex/tasks/task_e_68cd5cc6e15083248f588f2d3b2ad841